### PR TITLE
Fix Incorrect Sponsor Title

### DIFF
--- a/_data/speaker.yml
+++ b/_data/speaker.yml
@@ -141,7 +141,7 @@
 - index: 9
   name: Mark Chao
   avatar: "//avatars.githubusercontent.com/u/366910?v=3"
-  title: Listia
+  title: GitLab
   urlGithub: https://github.com/lulalala
   urltwitter: ''
   bio: "<p>A Rubyist from Taiwan who works for GitLab. My hobbies include traveling,


### PR DESCRIPTION
## Description

I believe Mark has already switched to GitLab, and the info is actually accurate in the `bio` section.
