### PR TITLE
adjust schedule page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,9 @@
 title: Ruby Conf Taiwan 2023
 cfp_link: https://cfp.rubyconf.tw/activities/2023
 register_link: https://rubytaiwan.kktix.cc/events/rubyconftw2023
-
+interpretation_link_day1: '#'
+interpretation_link_day2: '#'
+interpretation_link_enabled: false
 plugins:
   - jekyll-postcss
 

--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -19,6 +19,7 @@
       summary: Lessons Matz has learned from the history of Ruby development
       lang: "EN"
       speakers: [0]
+      online: true
 - id: 3
   day: 1
   room: L405
@@ -232,6 +233,7 @@
         AI agents are, and look at some of the latest cutting edge AI research.</p>"
       lang: "EN"
       speakers: [5]
+      online: true
 - id: 19
   day: 2
   time: '10:40' 
@@ -276,6 +278,7 @@
         在過去一年裏我們經歷了 LLM 的巨大衝擊，但是對於使用 LLM 實作應用依然困難重重。如何利用 Ruby 的 meta-programming 更好地對 LLM 進行處理和約束從而實作下一世代的 AI 應用是本 Topic 試圖討論的關鍵問題。
       lang: "CHT"
       speakers: [26]
+      online: true
     - session_id: 19
       room: L406
       subject: Monadic Approach to Ruby Error Handling

--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -19,7 +19,7 @@
       summary: Lessons Matz has learned from the history of Ruby development
       lang: "EN"
       speakers: [0]
-      online: true
+      online: false
 - id: 3
   day: 1
   room: L405

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -34,18 +34,18 @@
         <div x-show="day == {{item.day}}" x-data="{open_id: 0}">
           {% if item.title %}
           <!-- Title -->
-          <div class="grid grid-cols-3 justify-items-center items-center bg-zinc-100 font-medium text-base">
-            <div class="col-span-3 md:col-span-1 grid gap-1 justify-items-start py-5 font-semibold text-center text-2xl md:text-xl">
+          <div class="grid grid-cols-3 bg-zinc-100 font-medium text-base">
+            <div class="col-span-3 md:col-span-1 py-5 font-semibold text-center text-2xl md:text-xl">
               {{ item.time}}
             </div>
             <div
-              {% if item.title == 'Break' %}
-                class="col-span-3 md:col-span-2 grid gap-1 text-center justify-items-center py-5 uppercase text-lg font-bold text-gray"
-              {% else %}
-                class="col-span-3 md:col-span-2 grid gap-1 text-center justify-items-center py-5 uppercase text-lg font-bold text-dark-pink-100"
-              {% endif %}>
+              class="col-span-3 md:col-span-2 py-5 uppercase text-lg font-bold text-center
+                    {% if item.title == 'Break' %}text-gray{% else %}text-dark-pink-100{% endif %}">
               {{ item.title }}
             </div>
+            {% if item.panel %}
+              <div class="col-span-3 md:col-span-2 md:col-start-2 px-5 pb-5 text-center">{{ item.panel | markdownify }}</div>
+            {% endif %}
           </div>
           {% else %}
           <!-- sessions start -->
@@ -55,21 +55,20 @@
             </div>
             {% for session in item.sessions %}
             <!-- Speaker avatar and info -->
-            <button @click="open_id = {{session.session_id}}"
+            <div
               {% if session.room == 'L405' %}
-              class="group col-statr-1 md:col-start-2 col-span-3 md:col-span-1 grid gap-1 text-center justify-items-center"
+              class="col-statr-1 md:col-start-2 col-span-3 md:col-span-1 grid gap-1 text-center justify-items-center"
               {% elsif session.room == 'L406' %}
-              class="group col-statr-1 md:col-start-3 col-span-3 md:col-span-1 grid gap-1 text-center justify-items-center"
+              class="col-statr-1 md:col-start-3 col-span-3 md:col-span-1 grid gap-1 text-center justify-items-center"
               {% else %}
-              class="group col-span-3 md:col-span-2 grid gap-1 text-center justify-items-center"
+              class="col-span-3 md:col-span-2 grid gap-1 text-center justify-items-center"
               {% endif %}
             >
             {% for speaker_index in session.speakers %}
               {% assign speaker = site.data.speaker[speaker_index] %}
-              {% include schedule_card.html subject=session.subject lang=session.lang
-              speaker_name=speaker.name speaker_avatar=speaker.avatar room=session.room %}
+              {% include schedule_card.html session = session speaker = speaker %}
             {% endfor %}
-            </button>
+          </div>
             <!-- Modal start -->
             <div x-cloak x-show="open_id == {{session.session_id}}" class="fixed z-10" aria-labelledby="modal-title" role="dialog" aria-modal="true">
               {% include schedule_modal.html day=item.day time=item.time end=item.end speakers=session.speakers session=session %}
@@ -81,6 +80,16 @@
           {% endif%}
         </div>
         {% endfor %}
+        <!-- Simultaneous Interpretation Service -->
+        <div class="py-5 bg-dark-blue-200 text-white/80 text-center">
+          We offer
+          {% if site.interpretation_service %}
+          <a class="underline" target="_blank" href="{{site.interpretation_service}}">Simultaneous Interpretation Service</a>
+          {% else %}
+            Simultaneous Interpretation Service
+          {% endif %}
+          (Mandarin to English) on all Mandarin sessions.
+        </div>
       </div>
     </div>
   </div>

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -83,7 +83,11 @@
         <!-- Simultaneous Interpretation Service -->
         <div class="py-5 bg-dark-blue-200 text-white/80 text-center">
           We offer
+          {% if site.interpretation_link_enabled %}
           <a class="mr-1 underline cursor-pointer" target="_blank" x-bind:href="day == 1 ? '{{ site.interpretation_link_day1 }}': '{{ site.interpretation_link_day2 }}'"> Simultaneous Interpretation Service</a>
+          {% else %}
+          Simultaneous Interpretation Service
+          {% endif %}
           (Mandarin to English) on all Mandarin sessions.
         </div>
       </div>

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -83,11 +83,7 @@
         <!-- Simultaneous Interpretation Service -->
         <div class="py-5 bg-dark-blue-200 text-white/80 text-center">
           We offer
-          {% if site.interpretation_service %}
-          <a class="underline" target="_blank" href="{{site.interpretation_service}}">Simultaneous Interpretation Service</a>
-          {% else %}
-            Simultaneous Interpretation Service
-          {% endif %}
+          <a class="mr-1 underline cursor-pointer" target="_blank" x-bind:href="day == 1 ? '{{ site.interpretation_link_day1 }}': '{{ site.interpretation_link_day2 }}'"> Simultaneous Interpretation Service</a>
           (Mandarin to English) on all Mandarin sessions.
         </div>
       </div>

--- a/_includes/schedule_card.html
+++ b/_includes/schedule_card.html
@@ -33,6 +33,12 @@
 <div class="mt-2">
   <span class="font-normal uppercase bg-dark-pink-100 px-2.5 py-1 h-fit w-fit text-white rounded-md">{{ include.session.lang }}</span>
   {% if include.session.lang == 'CHT' %}
-  <span> | <a class="underline text-sm" target="_blank" href="{{session.interpretation_link}}">with English interpretation</a> </span>
+  <span class="ml-2 text-gray"> |
+    <a class="pl-2 underline text-sm text-gray"
+        href="{% if include.day == 1 %}{{site.interpretation_link_day1}}{% else %}{{site.interpretation_link_day2}}{% endif %}"
+        target="_blank">
+        with English interpretation
+    </a>
+  </span>
   {% endif %}
 </div>

--- a/_includes/schedule_card.html
+++ b/_includes/schedule_card.html
@@ -1,23 +1,38 @@
-{% if include.room%}
+<div class="flex justify-center">
+{% if include.session.room %}
 <p class="md:hidden font-normal uppercase bg-dark-blue-200 mt-8 mb-4 px-2.5 py-1 h-fit w-fit text-white rounded-md">
-  {{ include.room }}
+  {{ include.session.room }}
 </p>
 {% endif %}
-<div class="w-64 h-64">
-  <img
-    src="{{include.speaker_avatar}}"
-    class="w-full h-full mx-auto rounded-full border-4 border-dark-pink-100 object-cover"/>
+
+{% if include.session.online %}
+<p class="font-normal uppercase mt-8 mb-4 px-2.5 py-1 h-fit text-dark-pink-100 w-fitrounded-md">
+  <span class="hidden md:inline">●</span><span class="md:hidden">|</span> online
+</p>
+{% endif %}
 </div>
-<p class="text-gray text-xs">
-  <i class="fa fa-microphone pr-2 text-dark-pink-100"></i>
-  Speaker
-</p>
-<p class="group-hover:text-dark-pink-100 text-black text-xl font-bold">
-  {{ include.subject }}
-</p>
-<p class="text-black text-lg font-normal">
-  {{ include.speaker_name}}
-</p>
-<p class="font-normal uppercase bg-dark-pink-100 px-2.5 py-1 h-fit w-fit text-white rounded-md">
-  {{ include.lang }}
-</p>
+
+<div class="w-full group" @click="open_id = {{session.session_id}}">
+  <div class="w-64 h-64 mx-auto">
+    <img
+      src="{{include.speaker.avatar}}"
+      class="w-full h-full mx-auto rounded-full border-4 border-dark-pink-100 object-cover"/>
+  </div>
+  <p class="text-gray text-xs mt-2">
+    <i class="fa fa-microphone pr-2 text-dark-pink-100"></i>
+    Speaker
+  </p>
+  <p class="mt-4 group-hover:text-dark-pink-100 text-black text-xl font-bold">
+    {{ include.session.subject }}
+  </p>
+  <p class="mt-4 text-black text-lg font-normal">
+    {{ include.speaker.name}}
+  </p>
+</div>
+
+<div class="mt-2">
+  <span class="font-normal uppercase bg-dark-pink-100 px-2.5 py-1 h-fit w-fit text-white rounded-md">{{ include.session.lang }}</span>
+  {% if include.session.lang == 'CHT' %}
+  <span> | <a class="underline text-sm" target="_blank" href="{{session.interpretation_link}}">with English interpretation</a> </span>
+  {% endif %}
+</div>

--- a/_includes/schedule_card.html
+++ b/_includes/schedule_card.html
@@ -34,11 +34,15 @@
   <span class="font-normal uppercase bg-dark-pink-100 px-2.5 py-1 h-fit w-fit text-white rounded-md">{{ include.session.lang }}</span>
   {% if include.session.lang == 'CHT' %}
   <span class="ml-2 text-gray"> |
+    {% if site.interpretation_link_enabled %}
     <a class="pl-2 underline text-sm text-gray"
         href="{% if include.day == 1 %}{{site.interpretation_link_day1}}{% else %}{{site.interpretation_link_day2}}{% endif %}"
         target="_blank">
         with English interpretation
     </a>
+    {% else %}
+      with English interpretation
+    {% endif %}
   </span>
   {% endif %}
 </div>

--- a/_includes/schedule_modal.html
+++ b/_includes/schedule_modal.html
@@ -73,11 +73,15 @@
           </span>
           {% if include.session.lang == 'CHT' %}
             <span class="ml-2 text-gray"> |
+              {% if site.interpretation_link_enabled %}
               <a class="pl-2 underline text-sm text-gray"
                   href="{% if include.day == 1 %}{{site.interpretation_link_day1}}{% else %}{{site.interpretation_link_day2}}{% endif %}"
                   target="_blank">
                   with English interpretation
               </a>
+              {% else %}
+                with English interpretation
+              {% endif %}
             </span>
           {% endif %}
         </div>

--- a/_includes/schedule_modal.html
+++ b/_includes/schedule_modal.html
@@ -72,7 +72,13 @@
             {{ include.session.lang }}
           </span>
           {% if include.session.lang == 'CHT' %}
-            <span class="ml-2 text-gray"> | <a class="underline text-sm text-gray" target="_blank" href="{{session.interpretation_link}}">with English interpretation</a> </span>
+            <span class="ml-2 text-gray"> |
+              <a class="pl-2 underline text-sm text-gray"
+                  href="{% if include.day == 1 %}{{site.interpretation_link_day1}}{% else %}{{site.interpretation_link_day2}}{% endif %}"
+                  target="_blank">
+                  with English interpretation
+              </a>
+            </span>
           {% endif %}
         </div>
       </div>

--- a/_includes/schedule_modal.html
+++ b/_includes/schedule_modal.html
@@ -40,31 +40,41 @@
         {% endfor %}
       </div>
       <!-- session -->
-      <div class="col-span-5 md:col-span-3 mt-4 md:mt-0">
-        <div class='flex flex-col max-h-14 md:flex-row content-start md:content-center md:items-center flex-wrap'>
-          <p class="order-2 md:order-1 font-bold md:w-full">
+      <div class="col-span-5 md:col-span-3 mt-8 md:mt-0">
+        <div class="flex mr-4">
+          {% if include.session.room %}
+            <span class="rounded py-1 px-2 mr-3 bg-dark-pink-100 text-white text-sm font-blod">
+              {{ include.session.room }}
+            </span>
+          {% endif %}
+          {% if include.session.online %}
+            <span class="text-dark-pink-100">| online</span>
+          {% endif %}
+        </div>
+
+        <div class="mt-4 flex font-bold text-lg gap-x-4">
+          <span>
             {% if include.day == 1 %}
             2023/12/15
             {% elsif include.day ==2 %}
             2023/12/16
             {% endif %}
-          </p>
-          {% if include.session.room %}
-          <div class="flex items-center justify-center h-14 w-14 order-1 md:order-2">
-            <span class="rounded py-1 px-2 mr-3 bg-dark-pink-100 text-white text-sm font-blod">
-              {{ include.session.room }}
-            </span>
-          </div>
-          {% endif %}
-          <span  class="order-3 md:my-3 font-bold text-lg">
+          </span>
+          <span>
             {{ include.time }} ~ {{ include.end }}
           </span>
         </div>
-        <p class="text-xl md:text-2xl font-bold text-dark-blue-200">{{ include.session.subject }}</p>
+
+        <p class="mt-2 text-xl md:text-2xl font-bold text-dark-blue-200">{{ include.session.subject }}</p>
         <div class="markdownify mt-3">{{ include.session.summary | markdownify }}</div>
-        <p class="font-normal text-xs uppercase bg-dark-blue-200 px-2.5 py-1 h-fit w-fit text-white rounded-md">
-          {{ include.session.lang }}
-        </p>
+        <div class="flex">
+          <span class="font-normal text-xs uppercase bg-dark-blue-200 px-2.5 py-1 h-fit w-fit text-white rounded-md">
+            {{ include.session.lang }}
+          </span>
+          {% if include.session.lang == 'CHT' %}
+            <span class="ml-2 text-gray"> | <a class="underline text-sm text-gray" target="_blank" href="{{session.interpretation_link}}">with English interpretation</a> </span>
+          {% endif %}
+        </div>
       </div>
       <button @click="open_id=0" class="absolute right-5 top-5 text-2xl">
         <i class="fa fa-times text-dark-blue-200"></i>


### PR DESCRIPTION
- schedule session add online
   - schedule.yml  seesion add **online: true**
   ```
  online: true
  ```
   
- schedule official party add panel(markdonify)
   - schedule.yml  `official party `add `panel: ...........`
   ```
  title: Official Party
  panel: ...........
  ```
   
- add  `with English interpretation` (with link) to each schedule which lang eq 'CHT' 
   - config.yml   interpretation_link
   ```
   interpretation_link_day1: ...
   interpretation_link_day2: ...
   ```
   
- schedule add `we offer Simultaneous Interpretation Service (Mandarin to English) on all Mandarin sessions.`
   - day1 use interpretation_link_day1
   - day2 use interpretation_link_day2

|schedule|modal|
|----|----|
|![Screenshot 2023-12-04 at 4 37 34 PM](https://github.com/rubytaiwan/rubyconftw2023.github.io/assets/39110981/9ccf907c-2336-4bcc-a80f-4cefac1f0cd7)|![Screenshot 2023-12-04 at 4 39 04 PM](https://github.com/rubytaiwan/rubyconftw2023.github.io/assets/39110981/dac8eb49-2788-4eae-b688-261414ec7dca)|

|sm|md|
|----|----|
|![Screenshot 2023-12-04 at 4 42 53 PM](https://github.com/rubytaiwan/rubyconftw2023.github.io/assets/39110981/f036fe15-c9ae-4d4c-b7c2-4e1400ed5cf5)|![Screenshot 2023-12-04 at 4 43 02 PM](https://github.com/rubytaiwan/rubyconftw2023.github.io/assets/39110981/5926e777-990f-484f-9ebe-b631cc5dcea4)|



